### PR TITLE
Fix: path boundaries

### DIFF
--- a/src/php/template.php
+++ b/src/php/template.php
@@ -387,24 +387,55 @@ class Helpers
   }
 
   /**
-   * Checks if the passed path is above a base directory
+   * Checks if a path is the base directory itself or a descendant.
    * 
-   * $useRealpath resolves the paths using a string-based method
-   * as opposed to calling `realpath()` directly.
+   * Strict checking resolves symlinks; lexical checking only removes dot segments.
    *
    * @param String   $path          The path to check
    * @param String   $base          The base path
    * @param Boolean  $useRealpath   Whether to use realpath
    * 
-   * @return String
+   * @return Boolean
    */ 
   public static function isAboveCurrent($path, $base, $useRealpath = true)
   {
-    return self::startsWith($useRealpath
-      ? realpath($path)
-      : self::removeDotSegments($path), $useRealpath
-        ? realpath($base)
-        : self::removeDotSegments($base));
+    if($path === '' || $base === '')
+    {
+      return false;
+    }
+
+    if($useRealpath)
+    {
+      $path = realpath($path);
+      $base = realpath($base);
+      if($path === false || $base === false)
+      {
+        return false;
+      }
+    }
+
+    /* Windows accepts both separators; on Unix a backslash is a filename character. */
+    if(DIRECTORY_SEPARATOR === '\\')
+    {
+      $path = str_replace('\\', '/', $path);
+      $base = str_replace('\\', '/', $base);
+    }
+
+    if(!$useRealpath)
+    {
+      $path = self::removeDotSegments($path);
+      $base = self::removeDotSegments($base);
+      if($path === '' || $base === '')
+      {
+        return false;
+      }
+    }
+
+    $path = rtrim($path, '/');
+    $base = rtrim($base, '/');
+
+    /* Appending the separator also preserves '/' as a valid base. */
+    return $path === $base || self::startsWith($path, $base . '/');
   }
 
   /**

--- a/tests/php/PathBoundariesTest.php
+++ b/tests/php/PathBoundariesTest.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class PathBoundariesTest extends TestCase
+{
+    public function testBoundaryComparisonInStrictAndWeakModes(): void
+    {
+        $root = sys_get_temp_dir() . '/ivfi-boundaries-' . bin2hex(random_bytes(8));
+        $directories = [$root, $root . '/base', $root . '/base/child', $root . '/base-other'];
+        foreach($directories as $directory) {
+            mkdir($directory, 0700);
+        }
+
+        try {
+            $base = $root . '/base';
+            $cases = [];
+            $expected = [];
+            foreach(['strict' => true, 'weak' => false] as $mode => $resolve) {
+                foreach([
+                    'base itself' => [$base, $base, true],
+                    'descendant' => [$base . '/child', $base, true],
+                    'trailing separator' => [$base, $base . '/', true],
+                    'trailing separator on target' => [$base . '/child/', $base, true],
+                    'sibling with shared prefix' => [$root . '/base-other', $base, false],
+                    'traversal to sibling' => [$base . '/../base-other', $base, false],
+                    'parent' => [$root, $base, false],
+                    'empty base' => [$base, '', false],
+                    'empty target' => ['', $base, false],
+                ] as $name => [$path, $boundary, $allowed]) {
+                    $cases[$mode . ': ' . $name] = [$path, $boundary, $resolve];
+                    $expected[$mode . ': ' . $name] = $allowed;
+                }
+            }
+            foreach(['missing target' => [$root . '/missing', $base, true],
+                'missing base' => [$base, $root . '/missing', true]] as $name => $case) {
+                $cases[$name] = $case;
+                $expected[$name] = false;
+            }
+            if(DIRECTORY_SEPARATOR === '/') {
+                foreach([true, false] as $resolve) {
+                    $name = 'filesystem root ' . (int) $resolve;
+                    $cases[$name] = [$base, '/', $resolve];
+                    $expected[$name] = true;
+                    $cases[$name . ' itself'] = ['/', '/', $resolve];
+                    $expected[$name . ' itself'] = true;
+                }
+            }
+
+            $build = dirname(__DIR__, 2) . '/build/indexer.php';
+            self::assertFileExists($build, 'Run pnpm build before the PHP tests.');
+            $process = proc_open(
+                [PHP_BINARY, __DIR__ . '/check-boundaries.php', $build],
+                [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+                $pipes, $root
+            );
+            self::assertIsResource($process);
+            fwrite($pipes[0], json_encode(['uri' => '/', 'prepend' => '', 'cases' => $cases], JSON_THROW_ON_ERROR));
+            fclose($pipes[0]);
+            $output = stream_get_contents($pipes[1]);
+            $errors = stream_get_contents($pipes[2]);
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+            self::assertSame(0, proc_close($process), $errors);
+            self::assertSame('', $errors);
+            $results = json_decode($output, true, 512, JSON_THROW_ON_ERROR);
+            foreach($expected as $name => $allowed) {
+                self::assertSame($allowed, $results[$name], $name);
+            }
+        } finally {
+            foreach(array_reverse($directories) as $directory) {
+                rmdir($directory);
+            }
+        }
+    }
+}

--- a/tests/php/check-boundaries.php
+++ b/tests/php/check-boundaries.php
@@ -1,0 +1,11 @@
+<?php
+// Load the real generated page, discard its HTML, then exercise its helper.
+ob_start();
+require __DIR__ . '/render.php';
+ob_end_clean();
+
+$results = [];
+foreach($request['cases'] as $name => $case) {
+    $results[$name] = Helpers::isAboveCurrent($case[0], $case[1], $case[2]);
+}
+echo json_encode($results, JSON_THROW_ON_ERROR);


### PR DESCRIPTION
Fixes the path-boundary checks from #57 so similarly named directories aren’t mistaken for being inside the base directory. Also removes the weak-mode symlink bypass while keeping intentionally exposed symlinks working. Added tests too, covering both strict and weak mode.